### PR TITLE
Add GitHub/Twitter login to NewRecipe

### DIFF
--- a/_layouts/components/NewRecipe.js
+++ b/_layouts/components/NewRecipe.js
@@ -5,8 +5,7 @@ import { auth, currentUser } from "./oneGraphHelpers"
 const LoginButton = ({ auth, service, isLoggedIn, onUpdated }) => {
   return (
     <button
-      key={service.slug}
-      className="card w-64 m-4"
+      key={service}
       onClick={async () => {
         await auth.login(service)
         onUpdated(auth)

--- a/_layouts/components/NewRecipe.js
+++ b/_layouts/components/NewRecipe.js
@@ -1,5 +1,24 @@
 import React from "react"
 import { useFormik } from "formik"
+import { auth, currentUser } from "./oneGraphHelpers"
+
+const LoginButton = ({ auth, service, isLoggedIn, onUpdated }) => {
+  return (
+    <button
+      key={service.slug}
+      className="card w-64 m-4"
+      onClick={async () => {
+        await auth.login(service)
+        onUpdated(auth)
+      }}
+      disabled={isLoggedIn}
+    >
+      <h3>
+        {!!isLoggedIn ? " ✓" : ""} {service} &rarr;
+      </h3>
+    </button>
+  )
+}
 
 const SignupForm = () => {
   // Pass the useFormik() hook initial form values and a submit function that will
@@ -12,18 +31,81 @@ const SignupForm = () => {
       alert(JSON.stringify(values, null, 2))
     },
   })
+
+  const [accessToken, setAccessToken] = React.useState(
+    () => auth.accessToken() && auth.accessToken().accessToken
+  )
+  const resetAccessToken = auth => {
+    const newAccessToken = auth.accessToken() && auth.accessToken().accessToken
+    setAccessToken(newAccessToken)
+  }
+
+  const session = React.useMemo(
+    () => {
+      if (!!accessToken) {
+        const authGuardianData = currentUser(auth)
+        return authGuardianData.user
+      }
+    },
+    // Reset session data if the accessToken changes
+    [accessToken]
+  )
+
+  const isLoggedIntoGitHub = !!session?.user?.gitHubId
+  const isLoggedIntoTwitter = !!session?.user?.twitterId
+
   return (
-    <form onSubmit={formik.handleSubmit}>
-      <label htmlFor="email">Email Address</label>
-      <input
-        id="email"
-        name="email"
-        type="email"
-        onChange={formik.handleChange}
-        value={formik.values.email}
+    <>
+      <form onSubmit={formik.handleSubmit}>
+        <label htmlFor="email">Email Address</label>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          onChange={formik.handleChange}
+          value={formik.values.email}
+        />
+        <button type="submit">Submit</button>
+      </form>
+      <LoginButton
+        auth={auth}
+        service="github"
+        onUpdated={resetAccessToken}
+        isLoggedIn={isLoggedIntoGitHub}
       />
-      <button type="submit">Submit</button>
-    </form>
+      <LoginButton
+        auth={auth}
+        service="twitter"
+        onUpdated={resetAccessToken}
+        isLoggedIn={isLoggedIntoTwitter}
+      />
+      <button
+        onClick={() => {
+          auth.destroy()
+          resetAccessToken(auth)
+        }}
+      >
+        Log out all
+      </button>
+      {
+        // Debug area
+      }
+      <p>
+        Twitter:{" "}
+        {isLoggedIntoTwitter ? (
+          <>
+            {session?.user?.twitterScreenname} ({session?.user?.twitterId})
+          </>
+        ) : null}
+        <br />
+        GitHub:{" "}
+        {isLoggedIntoGitHub ? (
+          <>
+            {session?.user?.gitHubLogin} ({session?.user?.gitHubId})
+          </>
+        ) : null}
+      </p>
+    </>
   )
 }
 

--- a/_layouts/components/oneGraphHelpers.js
+++ b/_layouts/components/oneGraphHelpers.js
@@ -1,10 +1,10 @@
-import OneGraphAuth from "onegraph-auth";
+import OneGraphAuth from "onegraph-auth"
 
-export const ONE_GRAPH_APP_ID = "73a2441e-9638-496b-bf0b-b26c8c66720b";
-let isSsr = false;
+export const ONE_GRAPH_APP_ID = "73a2441e-9638-496b-bf0b-b26c8c66720b"
+let isSsr = false
 
 if (typeof window === "undefined") {
-  isSsr = true;
+  isSsr = true
 }
 
 export const auth = isSsr
@@ -15,24 +15,24 @@ export const auth = isSsr
   : new OneGraphAuth({
       appId: ONE_GRAPH_APP_ID,
       oneGraphOrigin: "https://serve.onegraph.com",
-    });
+    })
 
-export const currentUser = (auth) => {
-  if (isSsr) return { loading: true, user: null, error: null };
-  const accessToken = auth.accessToken();
+export const currentUser = auth => {
+  if (isSsr) return { loading: true, user: null, error: null }
+  const accessToken = auth.accessToken()
 
-  let decoded = null;
-  let error = null;
+  let decoded = null
+  let error = null
 
   if (!!accessToken) {
     try {
-      const payload = atob(accessToken.accessToken.split(".")[1]);
-      decoded = JSON.parse(payload);
-      delete decoded["https://onegraph.com/jwt/claims"];
+      const payload = atob(accessToken.accessToken.split(".")[1])
+      decoded = JSON.parse(payload)
+      delete decoded["https://onegraph.com/jwt/claims"]
     } catch (e) {
-      console.warn(`Error decoding OneGraph jwt for appId=${auth.appId}: `, e);
+      console.warn(`Error decoding OneGraph jwt for appId=${auth.appId}: `, e)
     }
   }
 
-  return { user: decoded, error: error, loading: false };
-};
+  return { user: decoded, error: error, loading: false }
+}

--- a/_layouts/components/oneGraphHelpers.js
+++ b/_layouts/components/oneGraphHelpers.js
@@ -1,0 +1,38 @@
+import OneGraphAuth from "onegraph-auth";
+
+export const ONE_GRAPH_APP_ID = "73a2441e-9638-496b-bf0b-b26c8c66720b";
+let isSsr = false;
+
+if (typeof window === "undefined") {
+  isSsr = true;
+}
+
+export const auth = isSsr
+  ? {
+      appId: ONE_GRAPH_APP_ID,
+      accessToken: () => null,
+    }
+  : new OneGraphAuth({
+      appId: ONE_GRAPH_APP_ID,
+      oneGraphOrigin: "https://serve.onegraph.com",
+    });
+
+export const currentUser = (auth) => {
+  if (isSsr) return { loading: true, user: null, error: null };
+  const accessToken = auth.accessToken();
+
+  let decoded = null;
+  let error = null;
+
+  if (!!accessToken) {
+    try {
+      const payload = atob(accessToken.accessToken.split(".")[1]);
+      decoded = JSON.parse(payload);
+      delete decoded["https://onegraph.com/jwt/claims"];
+    } catch (e) {
+      console.warn(`Error decoding OneGraph jwt for appId=${auth.appId}: `, e);
+    }
+  }
+
+  return { user: decoded, error: error, loading: false };
+};

--- a/_layouts/package.json
+++ b/_layouts/package.json
@@ -29,5 +29,9 @@
     "build": "gatsby build",
     "start": "gatsby serve"
   },
-  "devDependencies": {}
+  "devDependencies": {},
+  "prettier": {
+    "semi": false,
+    "arrowParens": "avoid"
+  }
 }

--- a/_layouts/package.json
+++ b/_layouts/package.json
@@ -13,6 +13,7 @@
     "gatsby-theme-garden": "^0.1.28",
     "gatsby-transformer-rehype": "^1.8.0",
     "gatsby-transformer-remark": "^2.8.27",
+    "onegraph-auth": "^2.2.4",
     "prism-theme-night-owl": "^1.4.0",
     "prismjs": "^1.20.0",
     "react": "^16.3.1",


### PR DESCRIPTION
![automatoes_third_party_login](https://user-images.githubusercontent.com/35296/89216817-f3702f80-d57f-11ea-9a40-eb2f323d7be2.gif)


Adds GitHub/Twitter login to the `<NewRecipe />` component. It doesn't do much with the information, just displays it, but should be enough to use anywhere else you're looking to!

You'll probably want to create your own OneGraph app for it, activate AuthGuardian, and set these rules to replicate everything (though you can use the existing app for development on localhost:8000):
![Screen Shot 2020-08-03 at 11 50 01 AM](https://user-images.githubusercontent.com/35296/89216852-0420a580-d580-11ea-9526-4235b2bb5c01.png)
![Screen Shot 2020-08-03 at 11 50 07 AM](https://user-images.githubusercontent.com/35296/89216855-05ea6900-d580-11ea-8852-4f1ee2c41ab9.png)


Also adds a `"prettier"` section to `package.json` that tries to mimic the code that's already there.